### PR TITLE
Add an argument for the pop-up position in wireless.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,12 @@ net_wireless = net_widgets.wireless({interface   = "wlp3s0",
 
 
 By default `indent = 3`
+
+#### Set the pop-up position
+
+Helpful if the widget is placed on the bottom bar and you want the pop-up to appear near the widget rather than on top of the screen.
+
+```Lua
+net_wireless = net_widgets.wireless({interface   = "wlp3s0",
+                                     popup_position = "bottom_right" })
+```

--- a/wireless.lua
+++ b/wireless.lua
@@ -18,6 +18,7 @@ local function worker(args)
     local timeout       = args.timeout or 5
     local font          = args.font or beautiful.font
     local popup_signal  = args.popup_signal or false
+    local popup_position = args.popup_position or naughty.config.defaults.position
     local onclick       = args.onclick
     local widget 	= args.widget == nil and wibox.layout.fixed.horizontal() or args.widget == false and nil or args.widget
     local indent 	= args.indent or 3
@@ -129,7 +130,8 @@ local function worker(args)
 		    preset = fs_notification_preset,
 		    text = text_grabber(),
 		    timeout = t_out,
-            screen = mouse.screen
+            screen = mouse.screen,
+            position = popup_position
 	    })
     end
     return widget or widgets_table


### PR DESCRIPTION
Hello! Thank you for your widget, I've added a small argument to position the pop-up notification on the screen. My toolbar is at the bottom and by default the pop-up appears on top, which is not handy.