### PR TITLE
[Fixed wired network indicator message]

### DIFF
--- a/indicator.lua
+++ b/indicator.lua
@@ -41,6 +41,10 @@ local function worker(args)
         "┌["..i.."]\n"..
         "├IP:\t"..inet.."\n"..
         "└MAC:\t"..mac.."</span>"
+
+	if int ~= "N/A" then
+	  break
+        end
       end
     else
       msg = "<span font_desc=\""..font.."\">Wired network is disconnected</span>"


### PR DESCRIPTION
Old message was always the one of the last interface of the list given
as argument whether or not it was used.