### PR TITLE
Improved VPN checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ If network is disconnected icon changes color to red. You can set multiple inter
 
 Note that you can show your wireless interface in here, but it won't show wireless-specific properties like signal strength or SSID. Use the wireless widget for that.
 
-Set `skipcmdline` to non-false if you don't want to show the command line of any process associated with the interface.  **NB**: the cmdline functionality requires passwordless `sudo find` and `sudo grep`
-
-Set `skipvpncheck` to non-false if you don't want to auto-detect a full-coverage VPN and change the icon.
+Set `skipcmdline` to non-false if you don't want to show the command line of any process associated with the interface.  Implies `skipvpncheck`.  **NB**: the cmdline functionality requires passwordless `sudo find` and `sudo grep`
 
 Set `skiproutes` to non-false if you don't want to show the routes associated with the interface.  Implies `skipvpncheck`.
+
+Set `skipvpncheck` to non-false if you don't want to auto-detect a full-route-coverage VPN and change the icon.  Supports OpenVPN, Cisco vpnc, and WireGuard.  **NB**: the WireGuard checks require passwordless `sudo wg`
 
 To create widget put in `rc.lua`
 ```Lua

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ If network is disconnected icon changes color to red. You can set multiple inter
 
 Note that you can show your wireless interface in here, but it won't show wireless-specific properties like signal strength or SSID. Use the wireless widget for that.
 
-Set `skipcmdline` to non-false if you don't want to show the command line of any process associated with the interface.  **NB**: the cmdline functionality requires passwordless `sudo bash`
+Set `skipcmdline` to non-false if you don't want to show the command line of any process associated with the interface.  **NB**: the cmdline functionality requires passwordless `sudo find` and `sudo grep`
 
-Set `skiproutes` to non-false if you don't want to show the routes associated with the interface.
+Set `skipvpncheck` to non-false if you don't want to auto-detect a full-coverage VPN and change the icon.
+
+Set `skiproutes` to non-false if you don't want to show the routes associated with the interface.  Implies `skipvpncheck`.
 
 To create widget put in `rc.lua`
 ```Lua

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ If network is disconnected icon changes color to red. You can set multiple inter
 
 Note that you can show your wireless interface in here, but it won't show wireless-specific properties like signal strength or SSID. Use the wireless widget for that.
 
-Set `skipcmdline` to non-false if you don't want to show the command line of any process associated with the interface.  Implies `skipvpncheck`.  **NB**: the cmdline functionality requires passwordless `sudo find` and `sudo grep`
+Set `skipcmdline` to false if you want to show the command line of any process associated with the interface.  If true, it implies `skipvpncheck`.  **NB**: the cmdline functionality requires passwordless `sudo find` and `sudo grep`
 
-Set `skiproutes` to non-false if you don't want to show the routes associated with the interface.  Implies `skipvpncheck`.
+Set `skiproutes` to false if you want to show the routes associated with the interface.  If true, implies `skipvpncheck`.
 
-Set `skipvpncheck` to non-false if you don't want to auto-detect a full-route-coverage VPN and change the icon.  Supports OpenVPN, Cisco vpnc, and WireGuard.  **NB**: the WireGuard checks require passwordless `sudo wg`
+Set `skipvpncheck` to false if you want to auto-detect a full-route-coverage VPN and change the icon.  Supports OpenVPN, Cisco vpnc, and WireGuard.  **NB**: the WireGuard checks require passwordless `sudo wg`
 
 To create widget put in `rc.lua`
 ```Lua

--- a/indicator.lua
+++ b/indicator.lua
@@ -22,7 +22,15 @@ local function worker(args)
   local onclick = args.onclick
   local hidedisconnected = args.hidedisconnected
   local popup_position = args.popup_position or naughty.config.defaults.position
-  if args.skiproutes or args.skipcmdline then
+
+  -- Turn off advanced details by default
+  if args.skiproutes == nil then
+    args.skiproutes = true
+  end
+  if args.skipcmdline == nil then
+    args.skipcmdline = true
+  end
+  if args.skipvpncheck == nil or args.skiproutes or args.skipcmdline then
     args.skipvpncheck = true
   end
 


### PR DESCRIPTION
Implement real checking for OpenVPN, WireGuard, and vpnc/Cisco3000 VPNs.  Only set the VPN icon if we detect a VPN interface that tries to route all internet traffic through themselves.

Still undone:
  - many VPN types aren't supported
  - a VPN interface might only *look* like it's routing all internet traffic, while in fact only routing some traffic
  - it's possible for a VPN to actually route all internet traffic but not look like it (e.g., bogons)

But this is an improvement and it covers my use cases, so...  :)
