### PR TITLE
fix wireless widget showing delayed information

### DIFF
--- a/wireless.lua
+++ b/wireless.lua
@@ -112,17 +112,17 @@ local function worker(args)
     local signal_level = 0
     local function net_update()
         awful.spawn.easy_async("awk 'NR==3 {printf \"%3.0f\" ,($3/70)*100}' /proc/net/wireless", function(stdout, stderr, reason, exit_code)
-          signal_level = tonumber( stdout )
+            signal_level = tonumber( stdout )
+            if signal_level == nil then
+                connected = false
+                net_text:set_text(" N/A ")
+                net_icon:set_image(draw_signal(0))
+            else
+                connected = true
+                net_text:set_text(string.format("%"..indent.."d%%", signal_level))
+                net_icon:set_image(draw_signal(signal_level))
+            end
         end)
-        if signal_level == nil then
-            connected = false
-            net_text:set_text(" N/A ")
-            net_icon:set_image(draw_signal(0))
-        else
-            connected = true
-            net_text:set_text(string.format("%"..indent.."d%%", signal_level))
-            net_icon:set_image(draw_signal(signal_level))
-        end
     end
 
     net_update()


### PR DESCRIPTION
Hi, great work! I've fixed a problem with the `net_update` function not waiting for the spawned async task to complete, which was causing the widget to display outdated info.
